### PR TITLE
Disallow non-ESM module format

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ In order to deploy a new contract on Arweave the SmartWeave client must:
 
 #### Contract source code specification
 
-1. A contract source code MAY be written in ES module format.
-2. A contract source MUST contain function (sync or async) named `handle`.
+1. A contract source code MUST be written in ES module format.
+2. A contract source MUST contain a function (sync or async) named `handle` in it's global scope.
 3. A contract source MAY use IIFE bundling format.
 4. The `handle` function MUST accept exactly two arguments: `state` and `action`
 5. The `state` argument MUST be the current state of the contract.


### PR DESCRIPTION
CJS and other _legacy_ systems are not portable. Contracts should never be using a module system in the first place, this just makes sure no syntax quirks are allowed in contracts. 

Also, the handler must be in the global scope (OR exported) of the contract. This makes life easier for implementors. We probably don't want to promote this weird Smartweave hack: https://github.com/ArweaveTeam/SmartWeave/blob/master/src/utils.ts#L93-L108

IIFE is still allowed, unfortunately, for backward compatibility.